### PR TITLE
#138 記事一覧取得を認証にて保護

### DIFF
--- a/cmd/app/api/main.go
+++ b/cmd/app/api/main.go
@@ -75,10 +75,7 @@ func main() {
 		panic(err)
 	}
 
-	secret := auth.Secret(cfg.JWTSecret)
-
 	authUsecase := interactor.NewAPIAuth(
-		secret,
 		authRPC,
 		userRPC,
 		authCache,
@@ -95,7 +92,7 @@ func main() {
 
 	si := handler.New(
 		cfg.APIKey,
-		secret,
+		auth.Secret(cfg.JWTSecret),
 		cookie.New(cfg.CookieDomain),
 		authUsecase,
 		articleUsecase,

--- a/cmd/app/api/main.go
+++ b/cmd/app/api/main.go
@@ -86,7 +86,10 @@ func main() {
 		sessionCache,
 	)
 
-	articleUsecase := interactor.NewAPIArticle(articleRPC)
+	articleUsecase := interactor.NewAPIArticle(
+		authCache,
+		articleRPC,
+	)
 
 	healthUsecase := interactor.NewAPIHealth(healthRPC)
 

--- a/e2e/helper/user.go
+++ b/e2e/helper/user.go
@@ -33,6 +33,7 @@ type User struct {
 	Key      *rsa.PrivateKey
 }
 
+//nolint:funlen
 func NewUser(
 	t *testing.T,
 	url string,
@@ -97,12 +98,14 @@ func NewUser(
 	}
 }
 
-func (us *User) Delete(t *testing.T) {
+func (user User) Delete(t *testing.T) {
+	t.Helper()
+
 	db := NewDatabase(t, GetDSN(t))
 
 	defer db.Close()
 
-	db.DeleteUser(uuid.MustParse(us.UserID))
+	db.DeleteUser(uuid.MustParse(user.UserID))
 }
 
 func Public(t *testing.T, private *rsa.PrivateKey) string {
@@ -136,7 +139,7 @@ func Public(t *testing.T, private *rsa.PrivateKey) string {
 	return strings.Join(pems, "")
 }
 
-func (user *User) Sign(code string) string {
+func (user User) Sign(code string) string {
 	user.T.Helper()
 
 	h := crypto.Hash.New(crypto.SHA256)

--- a/internal/adapter/handler/article.go
+++ b/internal/adapter/handler/article.go
@@ -34,9 +34,19 @@ func (hdl *Handler) V1ArticleList(w http.ResponseWriter, r *http.Request, params
 		return
 	}
 
+	uid, err := hdl.ExtractUserID(ctx, r)
+	if err != nil {
+		log.GetLogCtx(ctx).Warn("failed to extract user id", log.ErrorField(err))
+
+		w.WriteHeader(http.StatusUnauthorized)
+
+		return
+	}
+
 	input := usecase.APIArticleListInput{
-		Index: token.ToIndex(),
-		Size:  size,
+		UserID: uid,
+		Index:  token.ToIndex(),
+		Size:   size,
 	}
 
 	output, err := hdl.article.List(ctx, input)

--- a/internal/adapter/handler/auth_test.go
+++ b/internal/adapter/handler/auth_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/morning-night-guild/platform-app/internal/application/usecase"
 	"github.com/morning-night-guild/platform-app/internal/domain/model"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/auth"
-	"github.com/morning-night-guild/platform-app/internal/domain/model/user"
 	"github.com/morning-night-guild/platform-app/pkg/openapi"
 )
 
@@ -29,51 +28,6 @@ const (
 	sid = "01234567-0123-0123-0123-0123456789ab"
 	cid = "01234567-0123-0123-0123-0123456789ac"
 )
-
-func Cookie(t *testing.T) *handler.MockCookie {
-	t.Helper()
-
-	ctrl := gomock.NewController(t)
-
-	cookie := handler.NewMockCookie(ctrl)
-	cookie.EXPECT().Domain().Return("localhost").AnyTimes()
-	cookie.EXPECT().Secure().Return(false).AnyTimes()
-	cookie.EXPECT().SameSite().Return(http.SameSiteDefaultMode).AnyTimes()
-
-	return cookie
-}
-
-func GenerateToken(t *testing.T) struct {
-	UserID             user.ID
-	AuthToken          auth.AuthToken
-	AuthTokenString    string
-	SessionToken       auth.SessionToken
-	SessionTokenString string
-} {
-	t.Helper()
-
-	sid := auth.GenerateSessionID()
-
-	st := auth.GenerateSessionToken(sid, auth.Secret("secret"))
-
-	uid := user.GenerateID()
-
-	at := auth.GenerateAuthToken(uid, sid.ToSecret())
-
-	return struct {
-		UserID             user.ID
-		AuthToken          auth.AuthToken
-		AuthTokenString    string
-		SessionToken       auth.SessionToken
-		SessionTokenString string
-	}{
-		UserID:             uid,
-		AuthToken:          at,
-		AuthTokenString:    at.String(),
-		SessionToken:       st,
-		SessionTokenString: st.String(),
-	}
-}
 
 type Public struct {
 	T   *testing.T

--- a/internal/adapter/handler/auth_test.go
+++ b/internal/adapter/handler/auth_test.go
@@ -920,7 +920,7 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					}).Return(usecase.APIAuthGenerateCodeOutput{
 						Code: model.Code{
 							CodeID:    auth.CodeID(uuid.MustParse(cid)),
-							SessionID: token.SessionToken.GetID(auth.Secret("secret")),
+							SessionID: token.SessionToken.ID(auth.Secret("secret")),
 							IssuedAt:  time.Now(),
 							ExpiresAt: time.Now().Add(time.Minute * 10),
 						},
@@ -954,7 +954,7 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					}).Return(usecase.APIAuthGenerateCodeOutput{
 						Code: model.Code{
 							CodeID:    auth.CodeID(uuid.MustParse(cid)),
-							SessionID: token.SessionToken.GetID(auth.Secret("secret")),
+							SessionID: token.SessionToken.ID(auth.Secret("secret")),
 							IssuedAt:  time.Now(),
 							ExpiresAt: time.Now().Add(time.Minute * 10),
 						},
@@ -996,7 +996,7 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					}).Return(usecase.APIAuthGenerateCodeOutput{
 						Code: model.Code{
 							CodeID:    auth.CodeID(uuid.MustParse(cid)),
-							SessionID: token.SessionToken.GetID(auth.Secret("secret")),
+							SessionID: token.SessionToken.ID(auth.Secret("secret")),
 							IssuedAt:  time.Now(),
 							ExpiresAt: time.Now().Add(time.Minute * 10),
 						},

--- a/internal/adapter/handler/auth_test.go
+++ b/internal/adapter/handler/auth_test.go
@@ -44,6 +44,7 @@ func Cookie(t *testing.T) *handler.MockCookie {
 }
 
 func GenerateToken(t *testing.T) struct {
+	UserID             user.ID
 	AuthToken          auth.AuthToken
 	AuthTokenString    string
 	SessionToken       auth.SessionToken
@@ -55,14 +56,18 @@ func GenerateToken(t *testing.T) struct {
 
 	st := auth.GenerateSessionToken(sid, auth.Secret("secret"))
 
-	at := auth.GenerateAuthToken(user.GenerateID(), sid.ToSecret())
+	uid := user.GenerateID()
+
+	at := auth.GenerateAuthToken(uid, sid.ToSecret())
 
 	return struct {
+		UserID             user.ID
 		AuthToken          auth.AuthToken
 		AuthTokenString    string
 		SessionToken       auth.SessionToken
 		SessionTokenString string
 	}{
+		UserID:             uid,
 		AuthToken:          at,
 		AuthTokenString:    at.String(),
 		SessionToken:       st,

--- a/internal/adapter/handler/auth_test.go
+++ b/internal/adapter/handler/auth_test.go
@@ -154,9 +154,9 @@ func TestHandlerV1AuthRefresh(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().Refresh(gomock.Any(), usecase.APIAuthRefreshInput{
-						CodeID:       auth.CodeID(uuid.MustParse(cid)),
-						Signature:    auth.Signature("signature"),
-						SessionToken: auth.GenerateSessionToken(auth.SessionID(uuid.MustParse(sid)), "secret"),
+						CodeID:    auth.CodeID(uuid.MustParse(cid)),
+						Signature: auth.Signature("signature"),
+						SessionID: auth.SessionID(uuid.MustParse(sid)),
 					}).Return(usecase.APIAuthRefreshOutput{}, nil)
 					return mock
 				},
@@ -211,9 +211,9 @@ func TestHandlerV1AuthRefresh(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().Refresh(gomock.Any(), usecase.APIAuthRefreshInput{
-						CodeID:       auth.CodeID(uuid.MustParse(cid)),
-						Signature:    auth.Signature("signature"),
-						SessionToken: auth.GenerateSessionToken(auth.SessionID(uuid.MustParse(sid)), "secret"),
+						CodeID:    auth.CodeID(uuid.MustParse(cid)),
+						Signature: auth.Signature("signature"),
+						SessionID: auth.SessionID(uuid.MustParse(sid)),
 					}).Return(usecase.APIAuthRefreshOutput{}, fmt.Errorf("error"))
 					return mock
 				},
@@ -288,6 +288,7 @@ func TestHandlerV1AuthSignIn(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().SignIn(gomock.Any(), usecase.APIAuthSignInInput{
+						Secret:    auth.Secret("secret"),
 						EMail:     auth.EMail("test@example.com"),
 						Password:  auth.Password("password"),
 						PublicKey: pubkey.Key,
@@ -382,6 +383,7 @@ func TestHandlerV1AuthSignIn(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().SignIn(gomock.Any(), usecase.APIAuthSignInInput{
+						Secret:    auth.Secret("secret"),
 						EMail:     auth.EMail("test@example.com"),
 						Password:  auth.Password("password"),
 						PublicKey: pubkey.Key,
@@ -457,8 +459,8 @@ func TestHandlerV1AuthSignOut(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().SignOut(gomock.Any(), usecase.APIAuthSignOutInput{
-						AuthToken:    token.AuthToken,
-						SessionToken: token.SessionToken,
+						UserID:    token.UserID,
+						SessionID: token.SessionToken.ID(auth.Secret("secret")),
 					}).Return(usecase.APIAuthSignOutOutput{}, nil)
 					return mock
 				},
@@ -593,8 +595,8 @@ func TestHandlerV1AuthSignOut(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().SignOut(gomock.Any(), usecase.APIAuthSignOutInput{
-						AuthToken:    token.AuthToken,
-						SessionToken: token.SessionToken,
+						UserID:    token.UserID,
+						SessionID: token.SessionToken.ID(auth.Secret("secret")),
 					}).Return(usecase.APIAuthSignOutOutput{}, fmt.Errorf("error"))
 					return mock
 				},
@@ -841,8 +843,7 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().Verify(gomock.Any(), usecase.APIAuthVerifyInput{
-						AuthToken:    token.AuthToken,
-						SessionToken: token.SessionToken,
+						UserID: token.UserID,
 					}).Return(usecase.APIAuthVerifyOutput{}, nil)
 					return mock
 				},
@@ -921,7 +922,7 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().GenerateCode(gomock.Any(), usecase.APIAuthGenerateCodeInput{
-						SessionToken: token.SessionToken,
+						SessionID: token.SessionToken.ID(auth.Secret("secret")),
 					}).Return(usecase.APIAuthGenerateCodeOutput{
 						Code: model.Code{
 							CodeID:    auth.CodeID(uuid.MustParse(cid)),
@@ -955,7 +956,7 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().GenerateCode(gomock.Any(), usecase.APIAuthGenerateCodeInput{
-						SessionToken: token.SessionToken,
+						SessionID: token.SessionToken.ID(auth.Secret("secret")),
 					}).Return(usecase.APIAuthGenerateCodeOutput{
 						Code: model.Code{
 							CodeID:    auth.CodeID(uuid.MustParse(cid)),
@@ -993,11 +994,10 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().Verify(gomock.Any(), usecase.APIAuthVerifyInput{
-						AuthToken:    token.AuthToken,
-						SessionToken: token.SessionToken,
+						UserID: token.UserID,
 					}).Return(usecase.APIAuthVerifyOutput{}, fmt.Errorf("error"))
 					mock.EXPECT().GenerateCode(gomock.Any(), usecase.APIAuthGenerateCodeInput{
-						SessionToken: token.SessionToken,
+						SessionID: token.SessionToken.ID(auth.Secret("secret")),
 					}).Return(usecase.APIAuthGenerateCodeOutput{
 						Code: model.Code{
 							CodeID:    auth.CodeID(uuid.MustParse(cid)),
@@ -1035,11 +1035,10 @@ func TestHandlerV1AuthVerify(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					mock := usecase.NewMockAPIAuth(ctrl)
 					mock.EXPECT().Verify(gomock.Any(), usecase.APIAuthVerifyInput{
-						AuthToken:    token.AuthToken,
-						SessionToken: token.SessionToken,
+						UserID: token.UserID,
 					}).Return(usecase.APIAuthVerifyOutput{}, fmt.Errorf("error"))
 					mock.EXPECT().GenerateCode(gomock.Any(), usecase.APIAuthGenerateCodeInput{
-						SessionToken: token.SessionToken,
+						SessionID: token.SessionToken.ID(auth.Secret("secret")),
 					}).Return(usecase.APIAuthGenerateCodeOutput{}, fmt.Errorf("error"))
 					return mock
 				},

--- a/internal/adapter/handler/handler.go
+++ b/internal/adapter/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/morning-night-guild/platform-app/internal/application/usecase"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/auth"
 	derr "github.com/morning-night-guild/platform-app/internal/domain/model/errors"
+	"github.com/morning-night-guild/platform-app/internal/domain/model/user"
 	"github.com/morning-night-guild/platform-app/pkg/log"
 	"github.com/morning-night-guild/platform-app/pkg/openapi"
 	"github.com/morning-night-guild/platform-app/pkg/trace"
@@ -96,4 +97,43 @@ func NewRequestWithTID[T any](ctx context.Context, msg *T) *connect.Request[T] {
 	req.Header().Set("tid", trace.GetTIDCtx(ctx))
 
 	return req
+}
+
+func (hdl *Handler) ExtractUserID(
+	ctx context.Context,
+	r *http.Request,
+) (user.ID, error) {
+	sessionTokenCookie, err := r.Cookie(auth.SessionTokenKey)
+	if err != nil {
+		log.GetLogCtx(ctx).Warn("failed to get session token cookie", log.ErrorField(err))
+
+		return user.GenerateZeroID(), derr.NewUnauthorizedError("failed to get session token cookie", err)
+	}
+
+	sessionToken, err := auth.ParseSessionToken(sessionTokenCookie.Value, hdl.secret)
+	if err != nil {
+		log.GetLogCtx(ctx).Warn("failed to new session token", log.ErrorField(err))
+
+		return user.GenerateZeroID(), derr.NewUnauthorizedError("failed to new session token", err)
+	}
+
+	authTokenCookie, err := r.Cookie(auth.AuthTokenKey)
+	if err != nil {
+		log.GetLogCtx(ctx).Warn("failed to get auth token cookie", log.ErrorField(err))
+
+		return user.GenerateZeroID(), derr.NewUnauthorizedError("failed to get auth token cookie", err)
+	}
+
+	authToken, err := auth.ParseAuthToken(authTokenCookie.Value, sessionToken.ToSecret(hdl.secret))
+	if err != nil {
+		log.GetLogCtx(ctx).Warn("failed to new auth token", log.ErrorField(err))
+
+		return user.GenerateZeroID(), derr.NewUnauthorizedError("failed to new auth token", err)
+	}
+
+	sid := sessionToken.ID(hdl.secret)
+
+	uid := authToken.UserID(sid.ToSecret())
+
+	return uid, nil
 }

--- a/internal/adapter/handler/handler_test.go
+++ b/internal/adapter/handler/handler_test.go
@@ -4,12 +4,60 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/bufbuild/connect-go"
+	"github.com/golang/mock/gomock"
 	"github.com/morning-night-guild/platform-app/internal/adapter/handler"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/auth"
+	"github.com/morning-night-guild/platform-app/internal/domain/model/user"
 )
+
+func Cookie(t *testing.T) *handler.MockCookie {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+
+	cookie := handler.NewMockCookie(ctrl)
+	cookie.EXPECT().Domain().Return("localhost").AnyTimes()
+	cookie.EXPECT().Secure().Return(false).AnyTimes()
+	cookie.EXPECT().SameSite().Return(http.SameSiteDefaultMode).AnyTimes()
+
+	return cookie
+}
+
+func GenerateToken(t *testing.T) struct {
+	UserID             user.ID
+	AuthToken          auth.AuthToken
+	AuthTokenString    string
+	SessionToken       auth.SessionToken
+	SessionTokenString string
+} {
+	t.Helper()
+
+	sid := auth.GenerateSessionID()
+
+	st := auth.GenerateSessionToken(sid, auth.Secret("secret"))
+
+	uid := user.GenerateID()
+
+	at := auth.GenerateAuthToken(uid, sid.ToSecret())
+
+	return struct {
+		UserID             user.ID
+		AuthToken          auth.AuthToken
+		AuthTokenString    string
+		SessionToken       auth.SessionToken
+		SessionTokenString string
+	}{
+		UserID:             uid,
+		AuthToken:          at,
+		AuthTokenString:    at.String(),
+		SessionToken:       st,
+		SessionTokenString: st.String(),
+	}
+}
 
 func TestHandleConnectError(t *testing.T) {
 	t.Parallel()
@@ -97,6 +145,145 @@ func TestHandlerPointerToString(t *testing.T) {
 			)
 			if got := hdl.PointerToString(tt.args.s); got != tt.want {
 				t.Errorf("API.PointerToString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandlerExtractUserID(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		ctx     context.Context
+		r       *http.Request
+		cookies []*http.Cookie
+	}
+
+	token := GenerateToken(t)
+
+	tests := []struct {
+		name    string
+		args    args
+		want    user.ID
+		wantErr bool
+	}{
+		{
+			name: "cookieからUserIDを取り出せる",
+			args: args{
+				ctx: context.Background(),
+				r: &http.Request{
+					Header: http.Header{},
+				},
+				cookies: []*http.Cookie{
+					{
+						Name:  auth.AuthTokenKey,
+						Value: token.AuthTokenString,
+					},
+					{
+						Name:  auth.SessionTokenKey,
+						Value: token.SessionTokenString,
+					},
+				},
+			},
+			want:    user.ID(token.UserID),
+			wantErr: false,
+		},
+		{
+			name: "Sessionトークンが存在せずUserIDが取り出せない",
+			args: args{
+				ctx: context.Background(),
+				r: &http.Request{
+					Header: http.Header{},
+				},
+				cookies: []*http.Cookie{
+					{
+						Name:  auth.AuthTokenKey,
+						Value: token.AuthTokenString,
+					},
+				},
+			},
+			want:    user.GenerateZeroID(),
+			wantErr: true,
+		},
+		{
+			name: "Sessionトークンは存在するが不正な値でUserIDが取り出せない",
+			args: args{
+				ctx: context.Background(),
+				r: &http.Request{
+					Header: http.Header{},
+				},
+				cookies: []*http.Cookie{
+					{
+						Name:  auth.SessionTokenKey,
+						Value: "token",
+					},
+				},
+			},
+			want:    user.GenerateZeroID(),
+			wantErr: true,
+		},
+		{
+			name: "Authトークンが存在せずUserIDが取り出せない",
+			args: args{
+				ctx: context.Background(),
+				r: &http.Request{
+					Header: http.Header{},
+				},
+				cookies: []*http.Cookie{
+					{
+						Name:  auth.SessionTokenKey,
+						Value: token.SessionTokenString,
+					},
+				},
+			},
+			want:    user.GenerateZeroID(),
+			wantErr: true,
+		},
+		{
+			name: "Authトークンは存在するが不正な値でUserIDが取り出せない",
+			args: args{
+				ctx: context.Background(),
+				r: &http.Request{
+					Header: http.Header{},
+				},
+				cookies: []*http.Cookie{
+					{
+						Name:  auth.SessionTokenKey,
+						Value: token.SessionTokenString,
+					},
+					{
+						Name:  auth.AuthTokenKey,
+						Value: "token",
+					},
+				},
+			},
+			want:    user.GenerateZeroID(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			hdl := handler.New(
+				"",
+				auth.Secret("secret"),
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+			for _, cookie := range tt.args.cookies {
+				tt.args.r.AddCookie(cookie)
+			}
+			got, err := hdl.ExtractUserID(tt.args.ctx, tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Handler.ExtractUserID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Handler.ExtractUserID() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/adapter/handler/handler_test.go
+++ b/internal/adapter/handler/handler_test.go
@@ -185,7 +185,7 @@ func TestHandlerExtractUserID(t *testing.T) {
 					},
 				},
 			},
-			want:    user.ID(token.UserID),
+			want:    token.UserID,
 			wantErr: false,
 		},
 		{

--- a/internal/adapter/kvs/kvs.go
+++ b/internal/adapter/kvs/kvs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/morning-night-guild/platform-app/internal/domain/cache"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/errors"
+	"github.com/morning-night-guild/platform-app/pkg/log"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -32,6 +33,8 @@ func (kvs *KVS[T]) Get(ctx context.Context, key string) (T, error) {
 
 	str, err := kvs.Client.Get(ctx, key).Result()
 	if err != nil {
+		log.GetLogCtx(ctx).Warn("failed to get cache", log.ErrorField(err))
+
 		return value, errors.NewNotFoundError("failed to get cache", err)
 	}
 

--- a/internal/application/interactor/api_article.go
+++ b/internal/application/interactor/api_article.go
@@ -4,20 +4,27 @@ import (
 	"context"
 
 	"github.com/morning-night-guild/platform-app/internal/application/usecase"
+	"github.com/morning-night-guild/platform-app/internal/domain/cache"
+	"github.com/morning-night-guild/platform-app/internal/domain/model"
+	"github.com/morning-night-guild/platform-app/internal/domain/model/errors"
 	"github.com/morning-night-guild/platform-app/internal/domain/rpc"
+	"github.com/morning-night-guild/platform-app/pkg/log"
 )
 
 var _ usecase.APIArticle = (*APIArticle)(nil)
 
 // APIArticle.
 type APIArticle struct {
+	authCache  cache.Cache[model.Auth]
 	articleRPC rpc.Article
 }
 
 func NewAPIArticle(
+	authCache cache.Cache[model.Auth],
 	articleRPC rpc.Article,
 ) *APIArticle {
 	return &APIArticle{
+		authCache:  authCache,
 		articleRPC: articleRPC,
 	}
 }
@@ -40,6 +47,17 @@ func (aa *APIArticle) List(
 	ctx context.Context,
 	input usecase.APIArticleListInput,
 ) (usecase.APIArticleListOutput, error) {
+	auth, err := aa.authCache.Get(ctx, input.UserID.String())
+	if err != nil {
+		log.GetLogCtx(ctx).Warn("failed to get auth cache", log.ErrorField(err))
+
+		return usecase.APIArticleListOutput{}, errors.NewUnauthorizedError("failed to get auth cache", err)
+	}
+
+	if auth.IsExpired() {
+		return usecase.APIArticleListOutput{}, errors.NewUnauthorizedError("auth token is expired")
+	}
+
 	articles, err := aa.articleRPC.List(ctx, input.Index, input.Size)
 	if err != nil {
 		return usecase.APIArticleListOutput{}, err

--- a/internal/application/interactor/api_article_test.go
+++ b/internal/application/interactor/api_article_test.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"github.com/morning-night-guild/platform-app/internal/application/interactor"
 	"github.com/morning-night-guild/platform-app/internal/application/usecase"
+	"github.com/morning-night-guild/platform-app/internal/domain/cache"
 	"github.com/morning-night-guild/platform-app/internal/domain/model"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/article"
+	"github.com/morning-night-guild/platform-app/internal/domain/model/user"
 	"github.com/morning-night-guild/platform-app/internal/domain/rpc"
 	"github.com/morning-night-guild/platform-app/internal/domain/value"
 )
@@ -19,6 +23,7 @@ func TestAPIArticleShare(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
+		authCache  cache.Cache[model.Auth]
 		articleRPC func(t *testing.T) rpc.Article
 	}
 
@@ -116,7 +121,10 @@ func TestAPIArticleShare(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			aa := interactor.NewAPIArticle(tt.fields.articleRPC(t))
+			aa := interactor.NewAPIArticle(
+				tt.fields.authCache,
+				tt.fields.articleRPC(t),
+			)
 			got, err := aa.Share(tt.args.ctx, tt.args.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("APIArticle.Share() error = %v, wantErr %v", err, tt.wantErr)
@@ -133,6 +141,7 @@ func TestAPIArticleList(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
+		authCache  cache.Cache[model.Auth]
 		articleRPC func(t *testing.T) rpc.Article
 	}
 
@@ -158,6 +167,8 @@ func TestAPIArticleList(t *testing.T) {
 		},
 	}
 
+	now := time.Now()
+
 	tests := []struct {
 		name    string
 		fields  fields
@@ -168,6 +179,18 @@ func TestAPIArticleList(t *testing.T) {
 		{
 			name: "記事リストが取得できる",
 			fields: fields{
+				authCache: &cache.CacheMock[model.Auth]{
+					T: t,
+					Value: model.Auth{
+						AuthID:    user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+						UserID:    user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+						IssuedAt:  now,
+						ExpiresAt: now.Add(time.Hour * 24 * 30),
+					},
+					GetAssert: func(t *testing.T, key string) {
+						t.Helper()
+					},
+				},
 				articleRPC: func(t *testing.T) rpc.Article {
 					t.Helper()
 					ctrl := gomock.NewController(t)
@@ -179,8 +202,9 @@ func TestAPIArticleList(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIArticleListInput{
-					Index: value.Index(0),
-					Size:  value.Size(2),
+					UserID: user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+					Index:  value.Index(0),
+					Size:   value.Size(2),
 				},
 			},
 			want: usecase.APIArticleListOutput{
@@ -189,8 +213,49 @@ func TestAPIArticleList(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "認証に失敗する",
+			fields: fields{
+				authCache: &cache.CacheMock[model.Auth]{
+					T:     t,
+					Value: model.Auth{},
+					GetAssert: func(t *testing.T, key string) {
+						t.Helper()
+					},
+					GetErr: fmt.Errorf("test"),
+				},
+				articleRPC: func(t *testing.T) rpc.Article {
+					t.Helper()
+					ctrl := gomock.NewController(t)
+					mock := rpc.NewMockArticle(ctrl)
+					return mock
+				},
+			},
+			args: args{
+				ctx: context.Background(),
+				input: usecase.APIArticleListInput{
+					UserID: user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+					Index:  value.Index(0),
+					Size:   value.Size(2),
+				},
+			},
+			want:    usecase.APIArticleListOutput{},
+			wantErr: true,
+		},
+		{
 			name: "rpcでerrorが発生して記事リストが取得できない",
 			fields: fields{
+				authCache: &cache.CacheMock[model.Auth]{
+					T: t,
+					Value: model.Auth{
+						AuthID:    user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+						UserID:    user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+						IssuedAt:  now,
+						ExpiresAt: now.Add(time.Hour * 24 * 30),
+					},
+					GetAssert: func(t *testing.T, key string) {
+						t.Helper()
+					},
+				},
 				articleRPC: func(t *testing.T) rpc.Article {
 					t.Helper()
 					ctrl := gomock.NewController(t)
@@ -202,8 +267,9 @@ func TestAPIArticleList(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIArticleListInput{
-					Index: value.Index(0),
-					Size:  value.Size(2),
+					UserID: user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+					Index:  value.Index(0),
+					Size:   value.Size(2),
 				},
 			},
 			want:    usecase.APIArticleListOutput{},
@@ -215,7 +281,10 @@ func TestAPIArticleList(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			aa := interactor.NewAPIArticle(tt.fields.articleRPC(t))
+			aa := interactor.NewAPIArticle(
+				tt.fields.authCache,
+				tt.fields.articleRPC(t),
+			)
 			got, err := aa.List(tt.args.ctx, tt.args.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("APIArticle.List() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/application/interactor/api_auth.go
+++ b/internal/application/interactor/api_auth.go
@@ -96,9 +96,9 @@ func (aa *APIAuth) SignOut(
 	ctx context.Context,
 	input usecase.APIAuthSignOutInput,
 ) (usecase.APIAuthSignOutOutput, error) {
-	sid := input.SessionToken.GetID(aa.secret)
+	sid := input.SessionToken.ID(aa.secret)
 
-	uid := input.AuthToken.GetUserID(sid.ToSecret())
+	uid := input.AuthToken.UserID(sid.ToSecret())
 
 	if err := aa.sessionCache.Del(ctx, sid.String()); err != nil {
 		log.GetLogCtx(ctx).Warn("failed to delete session cache", log.ErrorField(err))
@@ -115,9 +115,9 @@ func (aa *APIAuth) Verify(
 	ctx context.Context,
 	input usecase.APIAuthVerifyInput,
 ) (usecase.APIAuthVerifyOutput, error) {
-	sid := input.SessionToken.GetID(aa.secret)
+	sid := input.SessionToken.ID(aa.secret)
 
-	uid := input.AuthToken.GetUserID(sid.ToSecret())
+	uid := input.AuthToken.UserID(sid.ToSecret())
 
 	auth, err := aa.authCache.Get(ctx, uid.String())
 	if err != nil {
@@ -127,7 +127,7 @@ func (aa *APIAuth) Verify(
 	}
 
 	if auth.IsExpired() {
-		return usecase.APIAuthVerifyOutput{}, errors.NewValidationError("auth token is expired")
+		return usecase.APIAuthVerifyOutput{}, errors.NewUnauthorizedError("auth token is expired")
 	}
 
 	return usecase.APIAuthVerifyOutput{}, nil
@@ -137,7 +137,7 @@ func (aa *APIAuth) Refresh(
 	ctx context.Context,
 	input usecase.APIAuthRefreshInput,
 ) (usecase.APIAuthRefreshOutput, error) {
-	sid := input.SessionToken.GetID(aa.secret)
+	sid := input.SessionToken.ID(aa.secret)
 
 	code, err := aa.codeCache.Get(ctx, sid.String())
 	if err != nil {
@@ -190,7 +190,7 @@ func (aa *APIAuth) GenerateCode(
 	ctx context.Context,
 	input usecase.APIAuthGenerateCodeInput,
 ) (usecase.APIAuthGenerateCodeOutput, error) {
-	sid := input.SessionToken.GetID(aa.secret)
+	sid := input.SessionToken.ID(aa.secret)
 
 	code := model.GenerateCode(sid)
 

--- a/internal/application/interactor/api_auth_test.go
+++ b/internal/application/interactor/api_auth_test.go
@@ -620,10 +620,7 @@ func TestAPIAuthRefresh(t *testing.T) {
 				input: usecase.APIAuthRefreshInput{
 					CodeID:    auth.CodeID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 					Signature: sign(t, key, "01234567-0123-0123-0123-0123456789ab"),
-					SessionID: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					).ID(auth.Secret("secret")),
+					SessionID: auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want:    usecase.APIAuthRefreshOutput{},

--- a/internal/application/interactor/api_auth_test.go
+++ b/internal/application/interactor/api_auth_test.go
@@ -54,7 +54,6 @@ func TestAPIAuthSignUp(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		secret       auth.Secret
 		authRPC      func(t *testing.T) rpc.Auth
 		userRPC      func(t *testing.T) rpc.User
 		authCache    cache.Cache[model.Auth]
@@ -178,7 +177,6 @@ func TestAPIAuthSignUp(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			aa := interactor.NewAPIAuth(
-				tt.fields.secret,
 				tt.fields.authRPC(t),
 				tt.fields.userRPC(t),
 				tt.fields.authCache,
@@ -201,7 +199,6 @@ func TestAPIAuthSignIn(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		secret       auth.Secret
 		authRPC      func(t *testing.T) rpc.Auth
 		userRPC      rpc.User
 		authCache    cache.Cache[model.Auth]
@@ -224,7 +221,6 @@ func TestAPIAuthSignIn(t *testing.T) {
 		{
 			name: "サインインできる",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				authRPC: func(t *testing.T) rpc.Auth {
 					t.Helper()
 					ctrl := gomock.NewController(t)
@@ -284,7 +280,6 @@ func TestAPIAuthSignIn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			aa := interactor.NewAPIAuth(
-				tt.fields.secret,
 				tt.fields.authRPC(t),
 				tt.fields.userRPC,
 				tt.fields.authCache,
@@ -307,7 +302,6 @@ func TestAPIAuthSignOut(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		secret       auth.Secret
 		authRPC      rpc.Auth
 		userRPC      rpc.User
 		authCache    cache.Cache[model.Auth]
@@ -330,7 +324,6 @@ func TestAPIAuthSignOut(t *testing.T) {
 		{
 			name: "サインアウトできる",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				authCache: &cache.CacheMock[model.Auth]{
 					T: t,
 					DelAssert: func(t *testing.T, key string) {
@@ -347,14 +340,8 @@ func TestAPIAuthSignOut(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIAuthSignOutInput{
-					AuthToken: auth.GenerateAuthToken(
-						user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")).ToSecret(),
-					),
-					SessionToken: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					),
+					UserID:    user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+					SessionID: auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want:    usecase.APIAuthSignOutOutput{},
@@ -363,7 +350,6 @@ func TestAPIAuthSignOut(t *testing.T) {
 		{
 			name: "AuthCache.Del()でエラーが発生してもサインアウトできる",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				authCache: &cache.CacheMock[model.Auth]{
 					T:      t,
 					DelErr: fmt.Errorf("test"),
@@ -381,14 +367,8 @@ func TestAPIAuthSignOut(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIAuthSignOutInput{
-					AuthToken: auth.GenerateAuthToken(
-						user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")).ToSecret(),
-					),
-					SessionToken: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					),
+					UserID:    user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+					SessionID: auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want:    usecase.APIAuthSignOutOutput{},
@@ -397,7 +377,6 @@ func TestAPIAuthSignOut(t *testing.T) {
 		{
 			name: "SessionCache.Del()でエラーが発生してもサインアウトできる",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				authCache: &cache.CacheMock[model.Auth]{
 					T: t,
 					DelAssert: func(t *testing.T, key string) {
@@ -415,14 +394,8 @@ func TestAPIAuthSignOut(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIAuthSignOutInput{
-					AuthToken: auth.GenerateAuthToken(
-						user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")).ToSecret(),
-					),
-					SessionToken: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					),
+					UserID:    user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+					SessionID: auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want:    usecase.APIAuthSignOutOutput{},
@@ -435,7 +408,6 @@ func TestAPIAuthSignOut(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			aa := interactor.NewAPIAuth(
-				tt.fields.secret,
 				tt.fields.authRPC,
 				tt.fields.userRPC,
 				tt.fields.authCache,
@@ -458,7 +430,6 @@ func TestAPIAuthVerify(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		secret       auth.Secret
 		authRPC      rpc.Auth
 		userRPC      rpc.User
 		authCache    cache.Cache[model.Auth]
@@ -483,7 +454,6 @@ func TestAPIAuthVerify(t *testing.T) {
 		{
 			name: "検証できる",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				authCache: &cache.CacheMock[model.Auth]{
 					T: t,
 					Value: model.Auth{
@@ -500,14 +470,7 @@ func TestAPIAuthVerify(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIAuthVerifyInput{
-					AuthToken: auth.GenerateAuthToken(
-						user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")).ToSecret(),
-					),
-					SessionToken: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					),
+					UserID: user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want:    usecase.APIAuthVerifyOutput{},
@@ -516,7 +479,6 @@ func TestAPIAuthVerify(t *testing.T) {
 		{
 			name: "AuthがCacheに存在せず検証に失敗する",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				authCache: &cache.CacheMock[model.Auth]{
 					T:      t,
 					Value:  model.Auth{},
@@ -529,14 +491,7 @@ func TestAPIAuthVerify(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIAuthVerifyInput{
-					AuthToken: auth.GenerateAuthToken(
-						user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")).ToSecret(),
-					),
-					SessionToken: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					),
+					UserID: user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want:    usecase.APIAuthVerifyOutput{},
@@ -545,7 +500,6 @@ func TestAPIAuthVerify(t *testing.T) {
 		{
 			name: "Authの有効期限が切れて検証に失敗する",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				authCache: &cache.CacheMock[model.Auth]{
 					T: t,
 					Value: model.Auth{
@@ -562,14 +516,7 @@ func TestAPIAuthVerify(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIAuthVerifyInput{
-					AuthToken: auth.GenerateAuthToken(
-						user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")).ToSecret(),
-					),
-					SessionToken: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					),
+					UserID: user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want:    usecase.APIAuthVerifyOutput{},
@@ -582,7 +529,6 @@ func TestAPIAuthVerify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			aa := interactor.NewAPIAuth(
-				tt.fields.secret,
 				tt.fields.authRPC,
 				tt.fields.userRPC,
 				tt.fields.authCache,
@@ -605,7 +551,6 @@ func TestAPIAuthRefresh(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		secret       auth.Secret
 		authRPC      rpc.Auth
 		userRPC      rpc.User
 		authCache    cache.Cache[model.Auth]
@@ -632,7 +577,6 @@ func TestAPIAuthRefresh(t *testing.T) {
 		{
 			name: "リフレッシュできる",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				codeCache: &cache.CacheMock[model.Code]{
 					T: t,
 					Value: model.Code{
@@ -676,10 +620,10 @@ func TestAPIAuthRefresh(t *testing.T) {
 				input: usecase.APIAuthRefreshInput{
 					CodeID:    auth.CodeID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 					Signature: sign(t, key, "01234567-0123-0123-0123-0123456789ab"),
-					SessionToken: auth.GenerateSessionToken(
+					SessionID: auth.GenerateSessionToken(
 						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 						auth.Secret("secret"),
-					),
+					).ID(auth.Secret("secret")),
 				},
 			},
 			want:    usecase.APIAuthRefreshOutput{},
@@ -692,7 +636,6 @@ func TestAPIAuthRefresh(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			aa := interactor.NewAPIAuth(
-				tt.fields.secret,
 				tt.fields.authRPC,
 				tt.fields.userRPC,
 				tt.fields.authCache,
@@ -715,7 +658,6 @@ func TestAPIAuthGenerateCode(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		secret       auth.Secret
 		authRPC      rpc.Auth
 		userRPC      rpc.User
 		authCache    cache.Cache[model.Auth]
@@ -740,7 +682,6 @@ func TestAPIAuthGenerateCode(t *testing.T) {
 		{
 			name: "コードが生成できる",
 			fields: fields{
-				secret: auth.Secret("secret"),
 				codeCache: &cache.CacheMock[model.Code]{
 					T: t,
 					SetAssert: func(t *testing.T, key string, value model.Code, ttl time.Duration) {
@@ -751,10 +692,7 @@ func TestAPIAuthGenerateCode(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				input: usecase.APIAuthGenerateCodeInput{
-					SessionToken: auth.GenerateSessionToken(
-						auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
-						auth.Secret("secret"),
-					),
+					SessionID: auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 				},
 			},
 			want: usecase.APIAuthGenerateCodeOutput{
@@ -774,7 +712,6 @@ func TestAPIAuthGenerateCode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			aa := interactor.NewAPIAuth(
-				tt.fields.secret,
 				tt.fields.authRPC,
 				tt.fields.userRPC,
 				tt.fields.authCache,

--- a/internal/application/usecase/api_article.go
+++ b/internal/application/usecase/api_article.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/morning-night-guild/platform-app/internal/domain/model"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/article"
+	"github.com/morning-night-guild/platform-app/internal/domain/model/user"
 	"github.com/morning-night-guild/platform-app/internal/domain/value"
 )
 
@@ -31,8 +32,9 @@ type APIArticleShareOutput struct {
 
 // APIArticleListInput.
 type APIArticleListInput struct {
-	Index value.Index
-	Size  value.Size
+	UserID user.ID
+	Index  value.Index
+	Size   value.Size
 }
 
 // APIArticleListOutput.

--- a/internal/application/usecase/api_auth.go
+++ b/internal/application/usecase/api_auth.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/morning-night-guild/platform-app/internal/domain/model"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/auth"
+	"github.com/morning-night-guild/platform-app/internal/domain/model/user"
 )
 
 //go:generate mockgen -source api_auth.go -destination api_auth_mock.go -package usecase
@@ -28,6 +29,7 @@ type APIAuthSignUpInput struct {
 type APIAuthSignUpOutput struct{}
 
 type APIAuthSignInInput struct {
+	Secret    auth.Secret
 	EMail     auth.EMail
 	Password  auth.Password
 	PublicKey rsa.PublicKey
@@ -40,21 +42,20 @@ type APIAuthSignInOutput struct {
 }
 
 type APIAuthSignOutInput struct {
-	AuthToken    auth.AuthToken
-	SessionToken auth.SessionToken
+	UserID    user.ID
+	SessionID auth.SessionID
 }
 
 type APIAuthSignOutOutput struct{}
 
 type APIAuthVerifyInput struct {
-	AuthToken    auth.AuthToken
-	SessionToken auth.SessionToken
+	UserID user.ID
 }
 
 type APIAuthVerifyOutput struct{}
 
 type APIAuthGenerateCodeInput struct {
-	SessionToken auth.SessionToken
+	SessionID auth.SessionID
 }
 
 type APIAuthGenerateCodeOutput struct {
@@ -62,9 +63,9 @@ type APIAuthGenerateCodeOutput struct {
 }
 
 type APIAuthRefreshInput struct {
-	CodeID       auth.CodeID
-	Signature    auth.Signature
-	SessionToken auth.SessionToken
+	CodeID    auth.CodeID
+	Signature auth.Signature
+	SessionID auth.SessionID
 }
 
 type APIAuthRefreshOutput struct {

--- a/internal/domain/model/auth/auth_token.go
+++ b/internal/domain/model/auth/auth_token.go
@@ -69,7 +69,7 @@ func (at AuthToken) String() string {
 	return string(at)
 }
 
-func (at AuthToken) GetUserID(secret Secret) user.ID {
+func (at AuthToken) UserID(secret Secret) user.ID {
 	parsedToken, _ := jwt.Parse(at.String(), func(token *jwt.Token) (interface{}, error) {
 		return []byte(secret.String()), nil
 	})

--- a/internal/domain/model/auth/session_token.go
+++ b/internal/domain/model/auth/session_token.go
@@ -68,7 +68,7 @@ func (st SessionToken) String() string {
 	return string(st)
 }
 
-func (st SessionToken) GetID(secret Secret) SessionID {
+func (st SessionToken) ID(secret Secret) SessionID {
 	parsedToken, _ := jwt.Parse(st.String(), func(token *jwt.Token) (interface{}, error) {
 		return []byte(secret.String()), nil
 	})
@@ -83,5 +83,5 @@ func (st SessionToken) GetID(secret Secret) SessionID {
 }
 
 func (st SessionToken) ToSecret(secret Secret) Secret {
-	return st.GetID(secret).ToSecret()
+	return st.ID(secret).ToSecret()
 }

--- a/internal/domain/model/user/id.go
+++ b/internal/domain/model/user/id.go
@@ -19,6 +19,10 @@ func GenerateID() ID {
 	return ID(uuid.New())
 }
 
+func GenerateZeroID() ID {
+	return ID(uuid.Nil)
+}
+
 // Value IDをuuid.UUID型として提供するメソッド.
 func (uid ID) Value() uuid.UUID {
 	return uuid.UUID(uid)


### PR DESCRIPTION
@Shitomo 

記事一覧取得APIを認証にて保護しました。

cookie 使っているのでクライアント修正不要で動くはずです。