### PR TITLE
#186 認証トークンの有効期限の最大値を3600sに変更

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -94,7 +94,7 @@ paths:
       tags:
         - auth
       summary: リフレッシュ
-      description: セッショントークンとクライアント署名によりIDトークンを再発行する
+      description: セッショントークンとクライアント署名により認証トークンを再発行する
       operationId: v1AuthRefresh
       security:
         - sessionTokenCookie: []
@@ -120,9 +120,9 @@ paths:
           schema:
             type: integer
             description: トークン有効期限(秒)
-            default: 86400
+            default: 3600
             minimum: 0
-            maximum: 86400
+            maximum: 3600
       responses:
         '200':
           description: OK
@@ -339,9 +339,9 @@ components:
         expiresIn:
           type: integer
           description: トークン有効期限(秒)
-          default: 86400
+          default: 3600
           minimum: 0
-          maximum: 86400
+          maximum: 3600
       required:
         - email
         - password

--- a/internal/adapter/handler/auth.go
+++ b/internal/adapter/handler/auth.go
@@ -57,10 +57,16 @@ func (hdl *Handler) V1AuthRefresh(w http.ResponseWriter, r *http.Request, params
 		return
 	}
 
+	expiresIn := auth.DefaultExpiresIn
+	if params.ExpiresIn != nil {
+		expiresIn = auth.ExpiresIn(*params.ExpiresIn)
+	}
+
 	input := usecase.APIAuthRefreshInput{
 		CodeID:    codeID,
 		Signature: signature,
 		SessionID: sessionToken.ID(hdl.secret),
+		ExpiresIn: expiresIn,
 	}
 
 	output, err := hdl.auth.Refresh(ctx, input)

--- a/internal/adapter/handler/auth.go
+++ b/internal/adapter/handler/auth.go
@@ -160,14 +160,12 @@ func (hdl *Handler) V1AuthSignIn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := time.Now()
-
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.AuthTokenKey,
 		Value:    output.AuthToken.String(),
 		Path:     path,
 		Domain:   hdl.cookie.Domain(),
-		Expires:  now.Add(model.DefaultAuthExpiresIn),
+		Expires:  output.Auth.ExpiresAt,
 		Secure:   hdl.cookie.Secure(),
 		HttpOnly: true,
 		SameSite: hdl.cookie.SameSite(),
@@ -178,7 +176,7 @@ func (hdl *Handler) V1AuthSignIn(w http.ResponseWriter, r *http.Request) {
 		Value:    output.SessionToken.String(),
 		Path:     path,
 		Domain:   hdl.cookie.Domain(),
-		Expires:  now.Add(model.DefaultSessionExpiresIn),
+		Expires:  output.Auth.IssuedAt.Add(model.DefaultSessionExpiresIn),
 		Secure:   hdl.cookie.Secure(),
 		HttpOnly: true,
 		SameSite: hdl.cookie.SameSite(),

--- a/internal/adapter/handler/auth_test.go
+++ b/internal/adapter/handler/auth_test.go
@@ -111,6 +111,7 @@ func TestHandlerV1AuthRefresh(t *testing.T) {
 						CodeID:    auth.CodeID(uuid.MustParse(cid)),
 						Signature: auth.Signature("signature"),
 						SessionID: auth.SessionID(uuid.MustParse(sid)),
+						ExpiresIn: auth.DefaultExpiresIn,
 					}).Return(usecase.APIAuthRefreshOutput{}, nil)
 					return mock
 				},
@@ -168,6 +169,7 @@ func TestHandlerV1AuthRefresh(t *testing.T) {
 						CodeID:    auth.CodeID(uuid.MustParse(cid)),
 						Signature: auth.Signature("signature"),
 						SessionID: auth.SessionID(uuid.MustParse(sid)),
+						ExpiresIn: auth.DefaultExpiresIn,
 					}).Return(usecase.APIAuthRefreshOutput{}, fmt.Errorf("error"))
 					return mock
 				},

--- a/internal/adapter/handler/auth_test.go
+++ b/internal/adapter/handler/auth_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/morning-night-guild/platform-app/internal/adapter/handler"
 	"github.com/morning-night-guild/platform-app/internal/application/usecase"
@@ -228,6 +228,8 @@ func TestHandlerV1AuthSignIn(t *testing.T) {
 
 	pubkey := NewPublicKey(t)
 
+	expiresIn := 600
+
 	tests := []struct {
 		name   string
 		fields fields
@@ -259,6 +261,36 @@ func TestHandlerV1AuthSignIn(t *testing.T) {
 					Email:     "test@example.com",
 					Password:  "password",
 					PublicKey: pubkey.String(),
+				},
+			},
+			status: http.StatusOK,
+		},
+		{
+			name: "有効期限を指定してサインインできる",
+			fields: fields{
+				auth: func(t *testing.T) usecase.APIAuth {
+					t.Helper()
+					ctrl := gomock.NewController(t)
+					mock := usecase.NewMockAPIAuth(ctrl)
+					mock.EXPECT().SignIn(gomock.Any(), usecase.APIAuthSignInInput{
+						Secret:    auth.Secret("secret"),
+						EMail:     auth.EMail("test@example.com"),
+						Password:  auth.Password("password"),
+						PublicKey: pubkey.Key,
+						ExpiresIn: auth.ExpiresIn(600),
+					}).Return(usecase.APIAuthSignInOutput{}, nil)
+					return mock
+				},
+			},
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+				},
+				body: openapi.V1AuthSignInRequestSchema{
+					Email:     "test@example.com",
+					Password:  "password",
+					PublicKey: pubkey.String(),
+					ExpiresIn: &expiresIn,
 				},
 			},
 			status: http.StatusOK,

--- a/internal/adapter/handler/handler_test.go
+++ b/internal/adapter/handler/handler_test.go
@@ -42,7 +42,7 @@ func GenerateToken(t *testing.T) struct {
 
 	uid := user.GenerateID()
 
-	at := auth.GenerateAuthToken(uid, sid.ToSecret())
+	at := auth.GenerateAuthToken(uid, sid.ToSecret(), auth.DefaultExpiresIn)
 
 	return struct {
 		UserID             user.ID

--- a/internal/application/interactor/api_auth.go
+++ b/internal/application/interactor/api_auth.go
@@ -73,7 +73,7 @@ func (aa *APIAuth) SignIn(
 		return usecase.APIAuthSignInOutput{}, err
 	}
 
-	at := model.IssueAuth(user.UserID)
+	at := model.IssueAuth(user.UserID, input.ExpiresIn)
 
 	aCmd, err := aa.authCache.CreateTxSetCmd(ctx, at.UserID.String(), at, at.ExpiresIn().Duration())
 	if err != nil {
@@ -161,7 +161,7 @@ func (aa *APIAuth) Refresh(
 		return usecase.APIAuthRefreshOutput{}, err
 	}
 
-	at := model.IssueAuth(session.UserID)
+	at := model.IssueAuth(session.UserID, input.ExpiresIn)
 
 	aCmd, err := aa.authCache.CreateTxSetCmd(ctx, at.UserID.String(), at, model.DefaultAuthExpiresIn)
 	if err != nil {

--- a/internal/application/interactor/api_auth.go
+++ b/internal/application/interactor/api_auth.go
@@ -75,7 +75,7 @@ func (aa *APIAuth) SignIn(
 
 	at := model.IssueAuth(user.UserID)
 
-	aCmd, err := aa.authCache.CreateTxSetCmd(ctx, at.UserID.String(), at, model.DefaultAuthExpiresIn)
+	aCmd, err := aa.authCache.CreateTxSetCmd(ctx, at.UserID.String(), at, at.ExpiresIn().Duration())
 	if err != nil {
 		return usecase.APIAuthSignInOutput{}, err
 	}
@@ -85,7 +85,8 @@ func (aa *APIAuth) SignIn(
 	}
 
 	return usecase.APIAuthSignInOutput{
-		AuthToken:    at.ToToken(session.SessionID.ToSecret()),
+		Auth:         at,
+		AuthToken:    at.ToToken(session.SessionID.ToSecret()), // secret を model.Auth{} にトークンに変換するときに secret が不要になる
 		SessionToken: session.ToToken(input.Secret),
 	}, nil
 }

--- a/internal/application/interactor/api_auth.go
+++ b/internal/application/interactor/api_auth.go
@@ -114,11 +114,11 @@ func (aa *APIAuth) Verify(
 	if err != nil {
 		log.GetLogCtx(ctx).Warn("failed to get auth cache", log.ErrorField(err))
 
-		return usecase.APIAuthVerifyOutput{}, err
+		return usecase.APIAuthVerifyOutput{}, errors.NewUnauthorizedError("not found auth", err)
 	}
 
 	if auth.IsExpired() {
-		return usecase.APIAuthVerifyOutput{}, errors.NewUnauthorizedError("auth token is expired")
+		return usecase.APIAuthVerifyOutput{}, errors.NewUnauthorizedError("auth is expired")
 	}
 
 	return usecase.APIAuthVerifyOutput{}, nil

--- a/internal/application/interactor/api_auth_test.go
+++ b/internal/application/interactor/api_auth_test.go
@@ -262,6 +262,7 @@ func TestAPIAuthSignIn(t *testing.T) {
 					EMail:     auth.EMail("test@example.com"),
 					Password:  auth.Password("password"),
 					PublicKey: rsa.PublicKey{},
+					ExpiresIn: auth.DefaultExpiresIn,
 				},
 			},
 			want: usecase.APIAuthSignInOutput{
@@ -627,6 +628,7 @@ func TestAPIAuthRefresh(t *testing.T) {
 					CodeID:    auth.CodeID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 					Signature: sign(t, key, "01234567-0123-0123-0123-0123456789ab"),
 					SessionID: auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+					ExpiresIn: auth.DefaultExpiresIn,
 				},
 			},
 			want:    usecase.APIAuthRefreshOutput{},

--- a/internal/application/interactor/api_auth_test.go
+++ b/internal/application/interactor/api_auth_test.go
@@ -269,6 +269,7 @@ func TestAPIAuthSignIn(t *testing.T) {
 				AuthToken: auth.GenerateAuthToken(
 					user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 					auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")).ToSecret(),
+					auth.DefaultExpiresIn,
 				),
 				SessionToken: auth.GenerateSessionToken(
 					auth.SessionID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),

--- a/internal/application/usecase/api_auth.go
+++ b/internal/application/usecase/api_auth.go
@@ -67,6 +67,7 @@ type APIAuthRefreshInput struct {
 	CodeID    auth.CodeID
 	Signature auth.Signature
 	SessionID auth.SessionID
+	ExpiresIn auth.ExpiresIn
 }
 
 type APIAuthRefreshOutput struct {

--- a/internal/application/usecase/api_auth.go
+++ b/internal/application/usecase/api_auth.go
@@ -37,6 +37,7 @@ type APIAuthSignInInput struct {
 }
 
 type APIAuthSignInOutput struct {
+	Auth         model.Auth
 	AuthToken    auth.AuthToken
 	SessionToken auth.SessionToken
 }
@@ -69,5 +70,6 @@ type APIAuthRefreshInput struct {
 }
 
 type APIAuthRefreshOutput struct {
+	Auth      model.Auth
 	AuthToken auth.AuthToken
 }

--- a/internal/domain/model/auth.go
+++ b/internal/domain/model/auth.go
@@ -66,7 +66,7 @@ func (at Auth) IsExpired() bool {
 func (at Auth) ToToken(
 	secret auth.Secret,
 ) auth.AuthToken {
-	return auth.GenerateAuthToken(at.UserID, secret)
+	return auth.GenerateAuthToken(at.UserID, secret, at.ExpiresIn())
 }
 
 func (at Auth) ExpiresIn() auth.ExpiresIn {

--- a/internal/domain/model/auth.go
+++ b/internal/domain/model/auth.go
@@ -67,3 +67,13 @@ func (at Auth) ToToken(
 ) auth.AuthToken {
 	return auth.GenerateAuthToken(at.UserID, secret)
 }
+
+func (at Auth) ExpiresIn() auth.ExpiresIn {
+	expiresIn := at.ExpiresAt.Unix() - time.Now().Unix()
+
+	if expiresIn > 0 {
+		return auth.ExpiresIn(expiresIn)
+	}
+
+	return auth.ExpiresIn(0)
+}

--- a/internal/domain/model/auth.go
+++ b/internal/domain/model/auth.go
@@ -39,6 +39,7 @@ func NewAuth(
 
 func IssueAuth(
 	userID user.ID,
+	expiresIn auth.ExpiresIn,
 ) Auth {
 	now := time.Now()
 
@@ -46,7 +47,7 @@ func IssueAuth(
 		AuthID:    userID,
 		UserID:    userID,
 		IssuedAt:  now,
-		ExpiresAt: now.Add(DefaultAuthExpiresIn),
+		ExpiresAt: now.Add(expiresIn.Duration()),
 	}
 }
 

--- a/internal/domain/model/auth/auth_token.go
+++ b/internal/domain/model/auth/auth_token.go
@@ -38,6 +38,7 @@ func GenerateAuthToken(
 	claims := jwt.MapClaims{
 		"sub": userID.String(),
 		"iat": now.Unix(),
+		"exp": now.Add(DefaultExpiresIn.Duration()).Unix(),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -75,7 +76,7 @@ func (at AuthToken) String() string {
 func (at AuthToken) UserID() user.ID {
 	decoded := strings.Split(at.String(), ".")
 
-	dec, err := base64.StdEncoding.DecodeString(decoded[1])
+	dec, err := base64.RawStdEncoding.Strict().DecodeString(decoded[1])
 	if err != nil {
 		return user.GenerateZeroID()
 	}

--- a/internal/domain/model/auth/auth_token.go
+++ b/internal/domain/model/auth/auth_token.go
@@ -32,13 +32,14 @@ func ParseAuthToken(
 func GenerateAuthToken(
 	userID user.ID,
 	secret Secret,
+	expiresIn ExpiresIn,
 ) AuthToken {
 	now := time.Now()
 
 	claims := jwt.MapClaims{
 		"sub": userID.String(),
 		"iat": now.Unix(),
-		"exp": now.Add(DefaultExpiresIn.Duration()).Unix(),
+		"exp": now.Add(expiresIn.Duration()).Unix(),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/internal/domain/model/auth/auth_token_test.go
+++ b/internal/domain/model/auth/auth_token_test.go
@@ -19,7 +19,7 @@ func TestAuthTokenUserID(t *testing.T) {
 	}{
 		{
 			name: "認証トークンからUserIDを取得できる",
-			at:   auth.GenerateAuthToken(user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")), auth.Secret("secret")),
+			at:   auth.GenerateAuthToken(user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")), auth.Secret("secret"), auth.DefaultExpiresIn),
 			want: user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
 		},
 	}

--- a/internal/domain/model/auth/auth_token_test.go
+++ b/internal/domain/model/auth/auth_token_test.go
@@ -34,3 +34,63 @@ func TestAuthTokenUserID(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAuthTokenToken(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		userID        user.ID
+		encryptSecret auth.Secret
+		expiresIn     auth.ExpiresIn
+		decryptSecret auth.Secret
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "認証トークンが生成できる",
+			args: args{
+				userID:        user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+				encryptSecret: auth.Secret("secret"),
+				expiresIn:     auth.DefaultExpiresIn,
+				decryptSecret: auth.Secret("secret"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "認証トークンの有効期限が切れている",
+			args: args{
+				userID:        user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+				encryptSecret: auth.Secret("secret"),
+				expiresIn:     auth.ExpiresIn(0),
+				decryptSecret: auth.Secret("secret"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "暗号化と復号化のシークレットが異なる",
+			args: args{
+				userID:        user.ID(uuid.MustParse("01234567-0123-0123-0123-0123456789ab")),
+				encryptSecret: auth.Secret("sencrypt"),
+				expiresIn:     auth.DefaultExpiresIn,
+				decryptSecret: auth.Secret("decrypt"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := auth.GenerateAuthToken(tt.args.userID, tt.args.encryptSecret, tt.args.expiresIn)
+			if _, err := auth.ParseAuthToken(got.String(), tt.args.decryptSecret); (err != nil) != tt.wantErr {
+				t.Errorf("ParseAuthToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/internal/domain/model/auth/expires_in.go
+++ b/internal/domain/model/auth/expires_in.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/morning-night-guild/platform-app/internal/domain/model/errors"
 )
@@ -25,6 +26,10 @@ func NewExpiresIn(value int) (ExpiresIn, error) {
 
 func (ei ExpiresIn) Int() int {
 	return int(ei)
+}
+
+func (ei ExpiresIn) Duration() time.Duration {
+	return time.Duration(ei.Int()) * time.Second
 }
 
 func (ei ExpiresIn) validate() error {

--- a/internal/domain/model/auth/expires_in.go
+++ b/internal/domain/model/auth/expires_in.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	DefaultExpiresInSecond = 86400 // 1 day (60s * 60m * 24h)
+	DefaultExpiresInSecond = 3600 // 1 hour (60s * 60m)
 	DefaultExpiresIn       = ExpiresIn(DefaultExpiresInSecond)
 )
 

--- a/internal/domain/model/auth/expires_in_test.go
+++ b/internal/domain/model/auth/expires_in_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/morning-night-guild/platform-app/internal/domain/model/auth"
 )
@@ -72,6 +73,32 @@ func TestNewExpiresIn(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("NewExpiresIn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpiresInDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ei   auth.ExpiresIn
+		want time.Duration
+	}{
+		{
+			name: "有効期限のDurationが取得できる",
+			ei:   auth.ExpiresIn(600),
+			want: time.Duration(600) * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.ei.Duration(); got != tt.want {
+				t.Errorf("ExpiresIn.Duration() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/domain/model/auth/expires_in_test.go
+++ b/internal/domain/model/auth/expires_in_test.go
@@ -28,19 +28,19 @@ func TestNewExpiresIn(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "有効期限(3600s)が作成できる",
+			name: "有効期限(600s)が作成できる",
+			args: args{
+				value: 600,
+			},
+			want:    auth.ExpiresIn(600),
+			wantErr: false,
+		},
+		{
+			name: "最大値で有効期限(3600s)が作成できる",
 			args: args{
 				value: 3600,
 			},
 			want:    auth.ExpiresIn(3600),
-			wantErr: false,
-		},
-		{
-			name: "最大値で有効期限(86400s)が作成できる",
-			args: args{
-				value: 86400,
-			},
-			want:    auth.ExpiresIn(86400),
 			wantErr: false,
 		},
 		{
@@ -52,9 +52,9 @@ func TestNewExpiresIn(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "最大値で有効期限(86400s)より大きい値で作成できない",
+			name: "最大値で有効期限(3600s)より大きい値で作成できない",
 			args: args{
-				value: 86401,
+				value: 3601,
 			},
 			want:    auth.ExpiresIn(-1),
 			wantErr: true,

--- a/internal/domain/model/auth_test.go
+++ b/internal/domain/model/auth_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/morning-night-guild/platform-app/internal/domain/model"
+	"github.com/morning-night-guild/platform-app/internal/domain/model/auth"
 	"github.com/morning-night-guild/platform-app/internal/domain/model/user"
 )
 
@@ -124,6 +125,58 @@ func TestAuthIsExpired(t *testing.T) {
 			}
 			if got := at.IsExpired(); got != tt.want {
 				t.Errorf("Auth.IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthExpiresIn(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		AuthID    user.ID
+		UserID    user.ID
+		IssuedAt  time.Time
+		ExpiresAt time.Time
+	}
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   auth.ExpiresIn
+	}{
+		{
+			name: "有効期限[s]が計算できる",
+			fields: fields{
+				IssuedAt:  now,
+				ExpiresAt: now.Add(time.Hour),
+			},
+			want: auth.ExpiresIn(time.Hour.Seconds()),
+		},
+		{
+			name: "有効期限[s]が0となる",
+			fields: fields{
+				IssuedAt:  now,
+				ExpiresAt: now.Add(-time.Hour),
+			},
+			want: auth.ExpiresIn(0),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			at := model.Auth{
+				AuthID:    tt.fields.AuthID,
+				UserID:    tt.fields.UserID,
+				IssuedAt:  tt.fields.IssuedAt,
+				ExpiresAt: tt.fields.ExpiresAt,
+			}
+			if got := at.ExpiresIn(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Auth.ExpiresIn() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
@Shitomo 

認証トークンの有効期限を3600sに変更しました。