### PR TITLE
#169 テーブル削除&テーブル作成&データインポートをワントランザクションに含めるように修正

### DIFF
--- a/cmd/db/backup/main.go
+++ b/cmd/db/backup/main.go
@@ -40,12 +40,25 @@ func main() {
 
 	defer secondary.Close()
 
-	if err := ResetTable(ctx, secondary); err != nil {
+	tx, err := secondary.Tx(ctx)
+	if err != nil {
+		log.Log().Panic("failed to begin transaction", log.ErrorField(err))
+	}
+
+	if err := ResetTable(ctx, tx); err != nil {
 		log.Log().Panic("failed to drop table", log.ErrorField(err))
 	}
 
-	if err := Import(ctx, secondary, entity); err != nil {
+	if err := Import(ctx, tx, entity); err != nil {
 		log.Log().Panic("failed to import", log.ErrorField(err))
+	}
+
+	if err := tx.Commit(); err != nil {
+		if err := tx.Rollback(); err != nil {
+			log.Log().Panic("failed to rollback transaction", log.ErrorField(err))
+		}
+
+		log.Log().Panic("failed to commit transaction", log.ErrorField(err))
 	}
 
 	log.GetLogCtx(ctx).Info("success backup")
@@ -85,13 +98,8 @@ func Export(ctx context.Context, client *gateway.RDB) (Entity, error) {
 const dropTableQuery = "DROP TABLE IF EXISTS %s CASCADE"
 
 //nolint:cyclop
-func ResetTable(ctx context.Context, client *gateway.RDB) error {
+func ResetTable(ctx context.Context, tx *ent.Tx) error {
 	log.GetLogCtx(ctx).Info("start drop table")
-
-	tx, err := client.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
 
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(dropTableQuery, user.Table)); err != nil {
 		if err := tx.Rollback(); err != nil {
@@ -121,27 +129,14 @@ func ResetTable(ctx context.Context, client *gateway.RDB) error {
 		log.Log().Panic("failed to create secondary schema", log.ErrorField(err))
 	}
 
-	if err := tx.Commit(); err != nil {
-		if err := tx.Rollback(); err != nil {
-			return fmt.Errorf("failed to rollback transaction: %w", err)
-		}
-
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-
 	log.GetLogCtx(ctx).Info("commit transaction")
 
 	return nil
 }
 
 //nolint:funlen
-func Import(ctx context.Context, client *gateway.RDB, entity Entity) error { //nolint:cyclop
+func Import(ctx context.Context, tx *ent.Tx, entity Entity) error { //nolint:cyclop
 	log.GetLogCtx(ctx).Info("start import")
-
-	tx, err := client.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
 
 	userBulk := make([]*ent.UserCreate, len(entity.Users))
 	for i, user := range entity.Users {
@@ -193,14 +188,6 @@ func Import(ctx context.Context, client *gateway.RDB, entity Entity) error { //n
 		}
 
 		return fmt.Errorf("failed to bulk create article tags: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		if err := tx.Rollback(); err != nil {
-			return fmt.Errorf("failed to rollback transaction: %w", err)
-		}
-
-		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	log.GetLogCtx(ctx).Info("commit transaction")


### PR DESCRIPTION
@Shitomo 

テーブル削除&テーブル作成&データインポートをワントランザクションに含めるように修正しました。
データマイグレーションが壊れたときはこの流れで対応できそうです。