### PR TITLE
chore(#202) デプロイではなくデリバリーに名称を修正

### DIFF
--- a/.github/workflows/container.delivery.yaml
+++ b/.github/workflows/container.delivery.yaml
@@ -1,4 +1,4 @@
-name: container deploy
+name: container delivery
 run-name: ${{ github.ref_name }} by @${{ github.actor }} ${{ github.workflow }}
 on:
   workflow_dispatch:


### PR DESCRIPTION
@Shitomo 

デプロイだと運用環境へのリリースまで含まれるため「デリバリー」としました。